### PR TITLE
Allow customization of link text

### DIFF
--- a/org-media-note.el
+++ b/org-media-note.el
@@ -275,7 +275,9 @@ jump to the correct position when opening the media for the first time."
         ;; (goto-char (match-end 1))
         ))
      ;; In a list of another type, don't break anything: throw an error.
-     (t (error "No playing media file now. Please open the media file first if you want to insert media note, \nor turn off ")))))
+     (t (error (concat "No playing media file now. Please open the media file"
+		       "first if you want to insert media note,"
+		       "\nor turn off "))))))
 
 (defun org-media-note-insert-link ()
   "Insert current mpv timestamp link into Org-mode note."

--- a/org-media-note.el
+++ b/org-media-note.el
@@ -67,7 +67,7 @@ If this value is not big enough, clicking the timestamp link may not
 jump to the correct position when opening the media for the first time."
   :type 'float)
 
-(defcustom org-media-note--link-format "%timestamp/%duration"
+(defcustom org-media-note-link-format "%timestamp/%duration"
   "Link text.  Allows the following substitutions:
 %filename :: name of the media file
 %timestamp :: current media timestamp (hms)
@@ -361,7 +361,7 @@ Returns:
       (format "[[%s:%s#%s][%s]]" link-type file-path
 	      timestamp
 	      (org-media-note--link-formatter
-	       org-media-note--link-format
+	       org-media-note-link-format
 	       `(("filename" . ,filename)
 		 ("duration" . ,duration)
 		 ("timestamp" . ,timestamp)

--- a/org-media-note.el
+++ b/org-media-note.el
@@ -40,11 +40,6 @@
   :group 'org
   :prefix "org-media-note-")
 
-(defcustom org-media-note-link-prefix nil
-  "Prefix inserted before timestamp in link text."
-  :type '(symbol string)
-  :options '(file-name file-path))
-
 (defcustom org-media-note-screenshot-image-dir org-directory
   "Default dir to save screenshots."
   :type 'string)
@@ -85,6 +80,14 @@ jump to the correct position when opening the media for the first time."
 before the link, or the point after?"
   :type 'symbol
   :options '(before after))
+
+(defcustom org-media-note-link-prefix ""
+  "Whether to prefix the link text with any text that is
+not part of the link.  Most common use is to insert a space
+that is not part of the link if the user sets 
+`org-media-note-cursor-start-position' to 'before, they likely
+want a space that is not part of the link itself."
+  :type 'string)
 
 ;;;; Variables
 
@@ -291,8 +294,10 @@ before the link, or the point after?"
   "Insert current mpv timestamp link into Org-mode note."
   (interactive)
   (let ((point (point)))
-    (insert (format "%s "
-                    (org-media-note--link)))
+    (insert
+     org-media-note-link-prefix
+     (format "%s "
+             (org-media-note--link)))
     (when (eq org-media-note-cursor-start-position 'before)
       (goto-char point))))
 

--- a/org-media-note.el
+++ b/org-media-note.el
@@ -68,8 +68,8 @@ jump to the correct position when opening the media for the first time."
   :type 'float)
 
 (defcustom org-media-note--link-format "%timestamp/%duration"
-  "Link text. Allows the following:
-%filename :: name of the current file
+  "Link text.  Allows the following substitutions:
+%filename :: name of the media file
 %timestamp :: current media timestamp (hms)
 %duration :: length of the media file (hms)
 %file-path :: path of the media file"
@@ -357,7 +357,7 @@ Returns:
                 link-type
                 (org-media-note--current-org-ref-key)
                 timestamp
-                hms)
+                timestamp)
       (format "[[%s:%s#%s][%s]]" link-type file-path
 	      timestamp
 	      (org-media-note--link-formatter

--- a/org-media-note.el
+++ b/org-media-note.el
@@ -305,16 +305,19 @@ pause the media."
 
 (defun org-media-note--link-formatter (string map)
   "MAP is an alist in the form of '((PLACEHOLDER . REPLACEMENT))
-STRING is the original string. PLACEHOLDER is a symbol or a string that will
-be converted to a string prefixed with a %: \"%PLACEHOLDER\". 
-REPLACEMENT can be a string, a number, symbol, or function. Replace all
-occurrences of %placeholder with replacement and return a new string.
+STRING is the original string.  Each placeholder can be a string, 
+symbol, or number. REPLACEMENT can be a string, a number, symbol, 
+or function. Replace all occurrences of %placeholder with replacement
+and return a new string.
 
-For example,
- (org-media-note--link-formatter \"%test1 / %test2\"
-               '((\"test1\" . \"asdf\")
-                 (\"test2\" . \"zxcv\")))
-Returns: \"asdf / zxcv\"."
+For example:
+(let ((input-string  \"Words,  %test1%test2 more words %test1.\")
+      (map '((test1 . \"asdf\")
+             (test2 . \"zxcv\"))))
+  (org-media-note--link-formatter input-string map))
+
+Returns:
+\"Words,  asdfzxcv more words asdf.\""
   (cl-loop for (holder . replacement) in map
 	   when replacement
 	   do (setq string
@@ -323,8 +326,10 @@ Returns: \"asdf / zxcv\"."
 			     (pcase holder
 			       ((pred symbolp) (symbol-name holder))
 			       ((pred stringp) holder)
-			       ((pred numberp) (number-to-string holder))))
+			       ((pred numberp) (number-to-string holder))
+			       ((pred functionp) (funcall replacement))))
 		     (pcase replacement
+		       ((pred symbolp) (symbol-name holder))
 		       ((pred stringp) replacement)
 		       ((pred numberp) (number-to-string replacement))
 		       ((pred functionp) (funcall replacement))


### PR DESCRIPTION
This is the second time I've ever tried a pull request, so bear with me if I didn't do this correctly. 

I added some features I needed for this package to be useful to me:
1. allow user to customize the link text using a string with replacement strings. See org-media-note-link-format. This also requires org-media-note--link-formatter;
2. custom option to move cursor to before the link text after it is inserted;
3. custom option to add a prefix string to link text that is not part of the link;
4. interactive function to insert a link and pause the video (to be able to take a note during the pause).

No idea if you like any of these features or the code, but wanted to share in case they were useful. 