### PR TITLE
Fix: declare dependencies

### DIFF
--- a/org-media-note.el
+++ b/org-media-note.el
@@ -5,7 +5,7 @@
 ;; Author: Yuchen Lea <yuchen.lea@gmail.com>
 ;; URL: https://github.com/yuchen-lea/org-media-note
 ;; Version: 1.7.0
-;; Package-Requires: ((emacs "27.1") mpv pretty-hydra)
+;; Package-Requires: ((emacs "27.1") (mpv "0.0") (pretty-hydra "0.0"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
Include versions for Package-Requires metadata.
Otherwise package managers will not properly handle installing dependencies.