### PR TITLE
Add checks for corrent data type

### DIFF
--- a/org-media-note-core.el
+++ b/org-media-note-core.el
@@ -196,7 +196,7 @@ This is useful when `org-media-note-cursor-start-position' is set to`before`."
 
 (defun org-media-note--online-video-p (path)
   "Return t if PATH is an HTTP URL."
-  (string-match "^http" path))
+  (string-match "^http" (if (stringp path) path "")))
 
 ;;;;; Add note
 ;;;;;; media note item
@@ -256,6 +256,7 @@ This is useful when `org-media-note-cursor-start-position' is set to`before`."
         (pos (mpv-get-playback-position)))
     (and (numberp time-a)
          (numberp time-b)
+         (numberp pos)
          (<= time-a pos)
          (<= pos time-b))))
 
@@ -400,6 +401,7 @@ Pass ARGS to ORIG-FN, `org-insert-item'."
 (defun org-media-note--format-file-path (path)
   "Convert PATH into the format defined by `org-link-file-path-type'."
   (cond
+   ((not (stringp path)) "")
    ((eq org-link-file-path-type 'absolute)
     (abbreviate-file-name (expand-file-name path)))
    ((eq org-link-file-path-type 'noabbrev)


### PR DESCRIPTION
Most of these functions rely on `mpv-get-property` and sometimes--with enough queue--`mpv-get-property` output the wrong data like time as url.

These checks are to prevent Emacs from erroring out.