### PR TITLE
bugfix org-timer import, when not using org-ref

### DIFF
--- a/org-media-note-core.el
+++ b/org-media-note-core.el
@@ -200,7 +200,10 @@ group 4: description tag")
   "Get media type of file at FILE-PATH."
   (let* ((file-ext (if file-path
                        (file-name-extension file-path))))
-    (org-media-note--get-media-type file-ext)))
+    (or
+     (org-media-note--get-media-type file-ext)
+     ;; if format is not known, video is better than nil
+     "video")))
 
 (defun org-media-note--get-media-type (file-ext)
   "Return media type based off of FILE-EXT."

--- a/org-media-note-import.el
+++ b/org-media-note-import.el
@@ -258,11 +258,14 @@
   "Convert `org-timer' to media link."
   (interactive)
   (let* ((key (org-media-note--current-org-ref-key))
-         (source-media (org-media-note-get-media-file-by-key key))
-         (media-file source-media)
+         (source-media (or (mpv-get-property "path") (user-error "org-media-note: no media file opened")))
+         (media-file-raw source-media)
+         ;; save some chars in links in homefolder, such as "/home/user" to "~"
+         (media-file (replace-regexp-in-string (expand-file-name "~") "~" media-file-raw))
          (media-link-type (org-media-note--file-media-type source-media)))
     (if (org-media-note-ref-cite-p)
         (progn
+          (setq source-media (org-media-note-get-media-file-by-key key))
           (setq media-file key)
           (setq media-link-type (format "%scite" media-link-type))))
     (save-excursion


### PR DESCRIPTION
fixes #46 

- proposed a default media-type to be video, which in terms of UX it is better than nil for a link
- org-media-note-get-media-file-by-key function is only defined when org-ref is enabled. Hence, moved after the conditional
- when no org-ref, no alternative file link, that is nil, so put the filename which mpv already has open and trigger error if fails
- proposed an additional process to save chars in the link