### PR TITLE
format-picture-file-name: scape ? symbol

### DIFF
--- a/org-media-note-core.el
+++ b/org-media-note-core.el
@@ -443,6 +443,7 @@ Pass ARGS to ORIG-FN, `org-insert-item'."
     (setq new-name (replace-regexp-in-string " - " "-" name))
     (setq new-name (replace-regexp-in-string ":" "_" new-name))
     (setq new-name (replace-regexp-in-string "\\." "_" new-name))
+    (setq new-name (replace-regexp-in-string "\\?" "-" new-name))
     (replace-regexp-in-string " " "_" new-name)))
 
 (defun org-media-note--format-file-path (path)


### PR DESCRIPTION
when opening a file link, it is easy that it could contain a ? symbol, and we don't want it to be interpreted as a regex which would avoid opening the file with the proper external app if configured

fixes #49