### PR TITLE
Fix opening mpv for URLs with % chars

### DIFF
--- a/org-media-note-core.el
+++ b/org-media-note-core.el
@@ -834,7 +834,7 @@ TIME-A and TIME-B indicate the start and end of a playback loop."
                       (mpv-get-property "path")))
         ;; file-path is not playing
         (progn
-          (message (format "open %s..." path))
+          (message "open %s..." path)
           (apply 'mpv-start path
                  (append (list (concat "--start=+" time-a))
                          (when time-b


### PR DESCRIPTION
For context, when first string arg to `message` contains `%` it is treated by `message` as a template string and it expects more args to come.
Basically, it acts as a `format`. Why? Go ask.
Docs:
https://www.gnu.org/software/emacs/manual/html_node/eintr/message.html

As a result, URLs with `%` in it were failing to open mpv on click due to error from `message`:
```
error: "Not enough arguments for format string"
```
E.g., for such a link:
``` org-mode
[[video:https://us02web.zoom.us/rec/play/ZIwV9OI_nOvLsM4E6qcWC95qzItbgYkySNmpunguzYC7X8amtyiQD1hTCMwZ5ETLAlVRh0Sgo1qmErQa.JamVkhsxNlyjU91t?canPlayFromShare=true&from=share_recording_detail&continueMode=true&componentName=rec-play&originRequestUrl=https%3A%2F%2Fus02web.zoom.us%2Frec%2Fshare%2Fkzc-Rsm_XOBvBMoSttIupf3MO8WmP-tEopTPh7WD9qykRWT1tvBGTrDMsMN8TCLq.qf1jJEwjs8A6xhwX#0:29:47][0:29:47]] yada yada
```