### PR TITLE
Fix missing dependency on s package

### DIFF
--- a/org-media-note-core.el
+++ b/org-media-note-core.el
@@ -9,6 +9,7 @@
 (require 'org)
 
 (require 'cl-lib)
+(require 's)
 
 (declare-function org-element-context "org-element" (&optional element))
 (declare-function org-element-property "org-element-ast" (property node &optional dflt force-undefer))

--- a/org-media-note.el
+++ b/org-media-note.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/yuchen-lea/org-media-note
 ;; Version: 1.11.0
 ;; Keywords: note-taking, multimedia, video
-;; Package-Requires: ((emacs "24.4") (org "9.3") (transient "0.1.0") (mpv "0.2.0"))
+;; Package-Requires: ((emacs "24.4") (org "9.3") (s "1.13.0") (transient "0.1.0") (mpv "0.2.0"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
Its `s-concat` function is used in `org-media-note-core.el`.